### PR TITLE
Show/Hide Button in CreateEditEntry-Form - Fixed

### DIFF
--- a/CreateEditEntry.cs
+++ b/CreateEditEntry.cs
@@ -51,7 +51,8 @@
             {
                 cb_showHidePasswd.Text = "Hide";
                 tB_password.UseSystemPasswordChar = false;
-                tB_password.Text = _password;
+                if(_password != null)
+                    tB_password.Text = _password;
             }
             else
             {


### PR DESCRIPTION
When I enter a password and press the "Show" button, the password is deleted again.. Its fixed 